### PR TITLE
Make the test setup more flexible.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,3 @@ log = "~0.3.4"
 maidsafe_utilities = "~0.1.5"
 rand = "~0.3.12"
 xor_name = "~0.0.1"
-
-[dev-dependencies]
-bit-vec = "~0.4.2"


### PR DESCRIPTION
The current tests fail with bucket size 2. We will need to modify the
tests so that they work for every (reasonable) bucket size before we can
change this value.

This change replaces the fixed close/mid/far contacts-in-buckets scheme
with one that allows for 256 contacts per bucket, so it will be easier
to adapt the tests later.