### PR TITLE
Make target_nodes recognise swarm, and whether we are the recipient.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub trait HasName {
 }
 
 /// A routing table entry representing a node and the connections to that node.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct NodeInfo<T, U>
     where U: Eq + Hash
 {
@@ -181,6 +181,18 @@ pub struct NodeInfo<T, U>
     /// The connections to the node, e. g. sockets or other kinds of connection handles.
     pub connections: HashSet<U>,
     bucket_index: usize,
+}
+
+impl<T, U> Clone for NodeInfo<T, U>
+    where U: Eq + Hash + Clone, T: Clone
+{
+    fn clone(&self) -> NodeInfo<T, U> {
+        NodeInfo {
+            public_id: self.public_id.clone(),
+            connections: self.connections.clone(),
+            bucket_index: self.bucket_index,
+        }
+    }
 }
 
 impl<T, U> NodeInfo<T, U>

--- a/src/result.rs
+++ b/src/result.rs
@@ -20,7 +20,7 @@ use super::NodeInfo;
 use xor_name::XorName;
 
 /// This is returned by `RoutingTable::add_node` if a new node has been added.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct AddedNodeDetails<T, U>
     where U: Eq + Hash
 {
@@ -36,7 +36,7 @@ pub struct AddedNodeDetails<T, U>
 ///
 /// If the dropped connection was the last one that connected us to one of the table's entries,
 /// that node is removed from the table.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct DroppedNodeDetails {
     /// The name of the dropped node.
     pub name: XorName,


### PR DESCRIPTION
This also removes HopType again: We need to know the previous hop anyway
to recognise whether the message is already coming from within the close
group.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/kademlia_routing_table/26)
<!-- Reviewable:end -->
