### PR TITLE
Make closest_nodes_to public.

### DIFF
--- a/src/contact_info.rs
+++ b/src/contact_info.rs
@@ -19,6 +19,6 @@ use xor_name::XorName;
 
 /// Contact info about a node in the network.
 pub trait ContactInfo: Clone + Eq {
-  /// Returns the name of this contact.
-  fn name(&self) -> &XorName;
+    /// Returns the name of this contact.
+    fn name(&self) -> &XorName;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,8 +469,10 @@ impl<T: ContactInfo> RoutingTable<T> {
 
     /// Returns the `n` nodes in our routing table that are closest to `target`.
     ///
-    /// Returns fewer than `n` nodes if the routing table doesn't have enough entries.
-    fn closest_nodes_to(&self, target: &XorName, n: usize, ourselves: bool) -> Vec<T> {
+    /// Returns fewer than `n` nodes if the routing table doesn't have enough entries. If
+    /// `ourselves` is `true`, this could potentially include ourselves. Otherwise, our own name is
+    /// skipped.
+    pub fn closest_nodes_to(&self, target: &XorName, n: usize, ourselves: bool) -> Vec<T> {
         let cmp = |a: &&T, b: &&T| target.cmp_distance(a.name(), b.name());
         // If we disagree with target in a bit, that bit's bucket contains contacts that are closer
         // to the target than we are. The lower the bucket index, the closer it is:
@@ -862,7 +864,9 @@ mod test {
 
         // Try with our ID (should return the rest of the close group)
         target_nodes = test.table
-                           .target_nodes(Destination::Group(test.table.our_name().clone()), &test.name, 0);
+                           .target_nodes(Destination::Group(test.table.our_name().clone()),
+                                         &test.name,
+                                         0);
         assert_eq!(GROUP_SIZE - 1, target_nodes.len());
 
         for i in ((TABLE_SIZE - GROUP_SIZE + 1)..TABLE_SIZE - 1).rev() {


### PR DESCRIPTION
This will be needed if we decide to implement tunnel nodes, to request the `n`-th closest node to the target as a tunnel.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/kademlia_routing_table/43)
<!-- Reviewable:end -->
